### PR TITLE
Feature/wagtail compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info
 *.pyc
 
+.idea
 
 /.cache
 /build/

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     'django-oscar>=1.6',
-    'wagtail>=2.0,<2.4',
+    'wagtail>=2.0'
 ]
 
 docs_require = [

--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,11 @@ tests_require = [
 
 setup(
     name='django-oscar-wagtail',
-    version='0.1.3',
+    version='0.1.4',
     description="Integration between Django Oscar and Wagtail",
     long_description=open('README.rst').read(),
-    author="Michael van Tellingen",
-    author_email="michaelvantellingen@gmail.com",
+    authors=["Michael van Tellingen",'C. Ryan Manzer'],
+    author_emails=["michaelvantellingen@gmail.com",'ryan.manzer@gmail.com'],
 
     install_requires=install_requires,
     tests_require=tests_require,

--- a/src/oscar_wagtail/views.py
+++ b/src/oscar_wagtail/views.py
@@ -6,7 +6,7 @@ from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.utils.six import text_type
 from oscar.core.loading import get_model
-from wagtail.admin.forms import SearchForm
+from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 
 Product = get_model('catalogue', 'Product')


### PR DESCRIPTION
I am attempting to provide compatibility with Wagtail 2.6.1.  This `feature` branch is where I am making these changes.  The current modifications simply adjust the import statement for the `wagtail.admin.search.SearchForm` and adjust the `setup.py` to permit installing with current versions of Wagtail and Django.