### PR TITLE
Upgrade to Wagtail >= 2.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     'django-oscar>=1.6',
-    'wagtail>=2.0,<2.4',
+    'wagtail>=2.4',
 ]
 
 docs_require = [

--- a/src/oscar_wagtail/views.py
+++ b/src/oscar_wagtail/views.py
@@ -6,7 +6,7 @@ from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.utils.six import text_type
 from oscar.core.loading import get_model
-from wagtail.admin.forms import SearchForm
+from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 
 Product = get_model('catalogue', 'Product')

--- a/src/oscar_wagtail/views.py
+++ b/src/oscar_wagtail/views.py
@@ -1,10 +1,10 @@
 import json
+from six import text_type
 
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.urls import reverse
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
-from django.utils.six import text_type
 from oscar.core.loading import get_model
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow


### PR DESCRIPTION
Just in case you're interested, here's what we did to get django-oscar-wagtail working on Wagtail 2.13. (django-oscar 2.1 was not a problem).